### PR TITLE
Move movement keys handling to js

### DIFF
--- a/ir/main.py
+++ b/ir/main.py
@@ -63,10 +63,6 @@ class ReadingManager:
         self.addModel()
         self.loadMenuItems()
         self.shortcuts = [
-            ('Down', self.viewManager.lineDown),
-            ('PgDown', self.viewManager.pageDown),
-            ('PgUp', self.viewManager.pageUp),
-            ('Up', self.viewManager.lineUp),
             (self.settings['extractKey'], self.textManager.extract),
             (self.settings['highlightKey'], self.textManager.highlight),
             (self.settings['removeKey'], self.textManager.remove),

--- a/ir/view.py
+++ b/ir/view.py
@@ -14,45 +14,23 @@
 # LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
-from typing import Any, Optional
-
 from anki.cards import Card
 from anki.hooks import addHook
 from aqt import mw
 from aqt import gui_hooks
-from aqt.reviewer import Reviewer
 
 from .util import isIrCard, loadFile, viewingIrText
 
 
 class ViewManager:
-    viewportHeight: float = None
-    pageBottom: float = None
-
     def __init__(self):
         self.scrollScript = loadFile('web', 'scroll.js')
         self.textScript = loadFile('web', 'text.js')
         self.widthScript = loadFile('web', 'width.js')
         self.zoomFactor = 1
         addHook('afterStateChange', self.resetZoom)
-        gui_hooks.webview_did_receive_js_message.append(self._store_page_info)
         gui_hooks.card_will_show.append(self._prepare_card)
         mw.web.page().scrollPositionChanged.connect(self.saveScroll)
-
-    def _store_page_info(self, handled: tuple[bool, Any], message: str, context: Any) -> tuple[bool, Any]:
-        if message == 'ir-store' and isinstance(context, Reviewer):
-            def callback(pageInfo: tuple[float, float]):
-                self.viewportHeight, self.pageBottom = pageInfo
-
-            mw.web.evalWithCallback(
-                '[window.innerHeight, document.body.scrollHeight];', callback
-            )
-
-            # Don't pass command to other handlers
-            return True, None
-        else:
-            # Some other command, pass it on
-            return handled
 
     def _prepare_card(self, html: str, card: Card, kind: str) -> str:
         if (isIrCard(card) and self.settings['limitWidth']) or self.settings['limitWidthAll']:
@@ -72,7 +50,9 @@ class ViewManager:
             self.setZoom()
             js += self.textScript
             js += self.scrollScript.format(
-                savedPos=self.settings['scroll'][cid]
+                savedPos=self.settings['scroll'][cid],
+                lineScrollFactor=self.settings['lineScrollFactor'],
+                pageScrollFactor=self.settings['pageScrollFactor'],
             )
 
         if js:
@@ -127,30 +107,6 @@ class ViewManager:
                 self.settings['scroll'][str(mw.reviewer.card.id)] = currentPos
 
             mw.web.evalWithCallback('window.pageYOffset;', callback)
-
-    def pageUp(self):
-        currentPos = self.settings['scroll'][str(mw.reviewer.card.id)]
-        movementSize = self.viewportHeight * self.settings['pageScrollFactor']
-        newPos = max(0, (currentPos - movementSize))
-        mw.web.eval('window.scrollTo(0, {});'.format(newPos))
-
-    def pageDown(self):
-        currentPos = self.settings['scroll'][str(mw.reviewer.card.id)]
-        movementSize = self.viewportHeight * self.settings['pageScrollFactor']
-        newPos = min(self.pageBottom, (currentPos + movementSize))
-        mw.web.eval('window.scrollTo(0, {});'.format(newPos))
-
-    def lineUp(self):
-        currentPos = self.settings['scroll'][str(mw.reviewer.card.id)]
-        movementSize = self.viewportHeight * self.settings['lineScrollFactor']
-        newPos = max(0, (currentPos - movementSize))
-        mw.web.eval('window.scrollTo(0, {});'.format(newPos))
-
-    def lineDown(self):
-        currentPos = self.settings['scroll'][str(mw.reviewer.card.id)]
-        movementSize = self.viewportHeight * self.settings['lineScrollFactor']
-        newPos = min(self.pageBottom, (currentPos + movementSize))
-        mw.web.eval('window.scrollTo(0, {});'.format(newPos))
 
     def resetZoom(self, state, *args):
         if not hasattr(self, 'settings'):

--- a/ir/web/scroll.js
+++ b/ir/web/scroll.js
@@ -15,7 +15,7 @@
  */
 
 function storePageInfo() {{
-    pycmd("store")
+    pycmd("ir-store")
 }}
 
 function restoreScroll() {{

--- a/ir/web/scroll.js
+++ b/ir/web/scroll.js
@@ -14,13 +14,38 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-function storePageInfo() {{
-    pycmd("ir-store")
-}}
-
 function restoreScroll() {{
     window.scrollTo(0, {savedPos});
 }}
 
-onUpdateHook.push(storePageInfo);
+function getMovementFactor(keyCode) {{
+    switch (keyCode) {{
+        case "ArrowUp":
+            return -{lineScrollFactor};
+        case "ArrowDown":
+            return {lineScrollFactor};
+        case "PageUp":
+            return -{pageScrollFactor};
+        case "PageDown":
+            return {pageScrollFactor};
+        default:
+            return 0;
+    }}
+}}
+
+document.addEventListener("keydown", (e) => {{
+    if (["ArrowUp", "ArrowDown", "PageUp", "PageDown"].includes(e.code)) {{
+        let currentPos = window.pageYOffset;
+
+        let movementSize = window.innerHeight * getMovementFactor(e.code);
+        let newPos = currentPos + movementSize;
+        newPos = Math.max(newPos, 0);
+        newPos = Math.min(newPos, document.body.scrollHeight);
+
+        window.scrollTo(0, newPos);
+
+        e.preventDefault();
+    }}
+}});
+
 onUpdateHook.push(restoreScroll);


### PR DESCRIPTION
### Notes

The incremental-reading movement key configs should only apply to IR card types. However, the previous implementation cannot distinguish between different card types and fails on non-IR card types (see issue below).

This PR moves the movement key handling to javascript so that if the card type is non-IR, we can fall back to the standard scrolling behavior. Moving to javascript is necessary as PyQt does not have default handlers for movement keys (https://forums.ankiweb.net/t/how-to-fallback-to-default-keystroke-handlers-for-shortcuts/23088). 

### Issue
https://github.com/tvhong/incremental-reading/issues/2