### PR TITLE
move link elements in 'head' into 'body'

### DIFF
--- a/ir/importer.py
+++ b/ir/importer.py
@@ -80,6 +80,12 @@ class Importer:
         for link in webpage.find_all('link'):
             self._processLinkTag(url, link, local)
 
+        headlinks = webpage.head.find_all('link')
+        headlinks.reverse()
+        for link in headlinks:
+            if 'stylesheet' in link['rel']:
+                webpage.body.insert(0, link)
+
         return webpage
 
     def _createNote(self, title, text, source, priority=None):


### PR DESCRIPTION
Anki seems to replace the original head element with it's own head element,which makes the CSS styles in the original document unusable. That's why we need to move the link elements in the 'head' element into the 'body' element