### PR TITLE
Specify encoding (utf-8) in importer.py

### DIFF
--- a/ir/importer.py
+++ b/ir/importer.py
@@ -70,7 +70,7 @@ class Importer:
         return self._cleanWebpage(html, url)
 
     def _fetchLocalpage(self, filepath):
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             html = f.read()
             url = urlunsplit(("file", "", filepath, None, None))
             return self._cleanWebpage(html, url, True)


### PR DESCRIPTION
This should be done as otherwise I get UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 883: ordinal not in range(128) on my machine. I think "utf-8" is the sane setting.