### PR TITLE
Fix packaging

### DIFF
--- a/ir/importer/__init__.py
+++ b/ir/importer/__init__.py
@@ -23,8 +23,7 @@ try:
 except ModuleNotFoundError:
     from PyQt5.QtCore import Qt
 
-from ir.settings import SettingsManager
-
+from ..settings import SettingsManager
 from .concrete_importers import (
     EpubImporter,
     FeedImporter,

--- a/ir/importer/base_importer.py
+++ b/ir/importer/base_importer.py
@@ -6,9 +6,8 @@ from anki.notes import Note
 from aqt import mw
 from aqt.utils import chooseList, showCritical, showWarning, tooltip
 
-from ir.settings import SettingsManager
-from ir.util import Article, setField
-
+from ..settings import SettingsManager
+from ..util import Article, setField
 from .exceptions import ErrorLevel, ImporterError
 from .models import NoteModel
 

--- a/ir/importer/concrete_importers.py
+++ b/ir/importer/concrete_importers.py
@@ -3,10 +3,9 @@ from urllib.parse import urlsplit
 
 from aqt.utils import getFile, getText
 
-from ir.lib.feedparser import parse
-from ir.settings import SettingsManager
-from ir.util import Article, selectArticles
-
+from ..lib.feedparser import parse
+from ..settings import SettingsManager
+from ..util import Article, selectArticles
 from .base_importer import BaseImporter
 from .epub import getEpubToc
 from .exceptions import ErrorLevel, ImporterError

--- a/ir/importer/epub.py
+++ b/ir/importer/epub.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import List
 from urllib.parse import urlsplit, urlunsplit
 
-from ir.util import Article
+from ..util import Article
 
 
 def nov_container_content_filename(filename):

--- a/ir/importer/pocket.py
+++ b/ir/importer/pocket.py
@@ -20,7 +20,7 @@ from anki.utils import is_mac, is_win
 from aqt.utils import askUser, openLink, showCritical, showInfo
 from requests import post
 
-from ir.util import Article
+from ..util import Article
 
 
 class Pocket:

--- a/ir/importer/web.py
+++ b/ir/importer/web.py
@@ -5,8 +5,7 @@ from attr import dataclass
 from bs4 import BeautifulSoup
 from requests import get
 
-from ir.settings import SettingsManager
-
+from ..settings import SettingsManager
 from .exceptions import ErrorLevel, ImporterError
 from .html_cleaner import HtmlCleaner
 


### PR DESCRIPTION
The previous refactoring uses the absolute import path `ir`, which doesn't work with the packaged addon. Fixing the code to use relative import instead.